### PR TITLE
first aid for manifest.js error.

### DIFF
--- a/app/assets/stylesheets/packs/.gitkeep
+++ b/app/assets/stylesheets/packs/.gitkeep
@@ -1,0 +1,4 @@
+# 応急処置
+# bootstrapをassetsで読み込めるようにすること
+stylesheets/pack
+!.gitkeep


### PR DESCRIPTION
Sprockets::ArgumentError:
link_directory argument must be a directory 
./app/assets/config/manifest.js:2

上記エラーに対する応急処置
アプリ公開後はBootstrapをassetから呼び出すようにすること